### PR TITLE
Add repository interfaces and use case implementations

### DIFF
--- a/app/src/main/java/com/gerardo/comandas/data/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/repositories/AuthRepository.kt
@@ -1,0 +1,6 @@
+package com.gerardo.comandas.data.repositories
+
+interface AuthRepository {
+    fun login(username: String, password: String): Boolean
+}
+

--- a/app/src/main/java/com/gerardo/comandas/data/repositories/MenuRepository.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/repositories/MenuRepository.kt
@@ -1,0 +1,9 @@
+package com.gerardo.comandas.data.repositories
+
+import com.gerardo.comandas.model.Producto
+
+interface MenuRepository {
+    fun getMenu(): List<Producto>
+    fun importPhotoForMenuItem(productId: Int, imagePath: String)
+}
+

--- a/app/src/main/java/com/gerardo/comandas/data/repositories/OrderRepository.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/repositories/OrderRepository.kt
@@ -1,0 +1,8 @@
+package com.gerardo.comandas.data.repositories
+
+interface OrderRepository {
+    fun createOrder(tableId: Int): Int
+    fun addOrderLine(orderId: Int, productId: Int, quantity: Int)
+    fun sendToPrinter(orderId: Int)
+}
+

--- a/app/src/main/java/com/gerardo/comandas/data/repositories/SettingsRepository.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/repositories/SettingsRepository.kt
@@ -1,0 +1,7 @@
+package com.gerardo.comandas.data.repositories
+
+interface SettingsRepository {
+    fun getSetting(key: String): String?
+    fun setSetting(key: String, value: String)
+}
+

--- a/app/src/main/java/com/gerardo/comandas/data/repositories/TableRepository.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/repositories/TableRepository.kt
@@ -1,0 +1,8 @@
+package com.gerardo.comandas.data.repositories
+
+interface TableRepository {
+    fun markAsPaid(tableId: Int)
+    fun setOccupied(tableId: Int)
+    fun setFree(tableId: Int)
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/AddOrderLine.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/AddOrderLine.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.OrderRepository
+
+class AddOrderLine(private val orderRepository: OrderRepository) {
+    operator fun invoke(orderId: Int, productId: Int, quantity: Int) {
+        orderRepository.addOrderLine(orderId, productId, quantity)
+    }
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/CreateOrder.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/CreateOrder.kt
@@ -1,0 +1,8 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.OrderRepository
+
+class CreateOrder(private val orderRepository: OrderRepository) {
+    operator fun invoke(tableId: Int): Int = orderRepository.createOrder(tableId)
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/GetMenu.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/GetMenu.kt
@@ -1,0 +1,9 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.MenuRepository
+import com.gerardo.comandas.model.Producto
+
+class GetMenu(private val menuRepository: MenuRepository) {
+    operator fun invoke(): List<Producto> = menuRepository.getMenu()
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/ImportPhotoForMenuItem.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/ImportPhotoForMenuItem.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.MenuRepository
+
+class ImportPhotoForMenuItem(private val menuRepository: MenuRepository) {
+    operator fun invoke(productId: Int, imagePath: String) {
+        menuRepository.importPhotoForMenuItem(productId, imagePath)
+    }
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/MarkTableAsPaid.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/MarkTableAsPaid.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.TableRepository
+
+class MarkTableAsPaid(private val tableRepository: TableRepository) {
+    operator fun invoke(tableId: Int) {
+        tableRepository.markAsPaid(tableId)
+    }
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/SendToPrinter.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/SendToPrinter.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.OrderRepository
+
+class SendToPrinter(private val orderRepository: OrderRepository) {
+    operator fun invoke(orderId: Int) {
+        orderRepository.sendToPrinter(orderId)
+    }
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/SetTableFree.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/SetTableFree.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.TableRepository
+
+class SetTableFree(private val tableRepository: TableRepository) {
+    operator fun invoke(tableId: Int) {
+        tableRepository.setFree(tableId)
+    }
+}
+

--- a/app/src/main/java/com/gerardo/comandas/domain/usecases/SetTableOccupied.kt
+++ b/app/src/main/java/com/gerardo/comandas/domain/usecases/SetTableOccupied.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.domain.usecases
+
+import com.gerardo.comandas.data.repositories.TableRepository
+
+class SetTableOccupied(private val tableRepository: TableRepository) {
+    operator fun invoke(tableId: Int) {
+        tableRepository.setOccupied(tableId)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add repository interfaces for menu, orders, tables, auth, and settings
- implement use case classes for menu, orders, table management, printing, and photo import

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af00b603688329bd32f916e296a236