### PR TITLE
Implement Room database with seed data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.kapt")
 }
 
 android {
@@ -56,6 +57,10 @@ dependencies {
     implementation("androidx.compose.animation:animation")
     // implementation("androidx.compose.material:material") // Eliminar Material2 si no se usa
     implementation("com.google.accompanist:accompanist-navigation-animation:0.34.0")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")

--- a/app/src/main/java/com/gerardo/comandas/data/room/Category.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/Category.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "categories")
+data class Category(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/CategoryDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/CategoryDao.kt
@@ -1,0 +1,15 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface CategoryDao {
+    @Query("SELECT * FROM categories")
+    suspend fun getAll(): List<Category>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(categories: List<Category>)
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/MenuItem.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/MenuItem.kt
@@ -1,0 +1,23 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "menu_items",
+    foreignKeys = [ForeignKey(
+        entity = Category::class,
+        parentColumns = ["id"],
+        childColumns = ["categoryId"],
+        onDelete = ForeignKey.CASCADE
+    )],
+    indices = [Index("categoryId")]
+)
+data class MenuItem(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String,
+    val price: Double,
+    val categoryId: Int
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/MenuItemDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/MenuItemDao.kt
@@ -1,0 +1,18 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface MenuItemDao {
+    @Query("SELECT * FROM menu_items")
+    suspend fun getAll(): List<MenuItem>
+
+    @Query("SELECT * FROM menu_items WHERE categoryId = :categoryId")
+    suspend fun getByCategory(categoryId: Int): List<MenuItem>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<MenuItem>)
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/Order.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/Order.kt
@@ -1,0 +1,22 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "orders",
+    foreignKeys = [ForeignKey(
+        entity = TableSpot::class,
+        parentColumns = ["id"],
+        childColumns = ["tableId"],
+        onDelete = ForeignKey.CASCADE
+    )],
+    indices = [Index("tableId")]
+)
+data class Order(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val tableId: Int,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/OrderDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/OrderDao.kt
@@ -1,0 +1,14 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface OrderDao {
+    @Query("SELECT * FROM orders")
+    suspend fun getAll(): List<Order>
+
+    @Insert
+    suspend fun insert(order: Order): Long
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/OrderLine.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/OrderLine.kt
@@ -1,0 +1,31 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "order_lines",
+    foreignKeys = [
+        ForeignKey(
+            entity = Order::class,
+            parentColumns = ["id"],
+            childColumns = ["orderId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = MenuItem::class,
+            parentColumns = ["id"],
+            childColumns = ["menuItemId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("orderId"), Index("menuItemId")]
+)
+data class OrderLine(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val orderId: Int,
+    val menuItemId: Int,
+    val quantity: Int
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/OrderLineDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/OrderLineDao.kt
@@ -1,0 +1,14 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface OrderLineDao {
+    @Query("SELECT * FROM order_lines WHERE orderId = :orderId")
+    suspend fun getByOrder(orderId: Int): List<OrderLine>
+
+    @Insert
+    suspend fun insertAll(lines: List<OrderLine>)
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/RetroBurgerDatabase.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/RetroBurgerDatabase.kt
@@ -1,0 +1,50 @@
+package com.gerardo.comandas.data.room
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import java.util.concurrent.Executors
+
+@Database(
+    entities = [Category::class, MenuItem::class, Zone::class, TableSpot::class, Order::class, OrderLine::class],
+    version = 1
+)
+abstract class RetroBurgerDatabase : RoomDatabase() {
+    abstract fun categoryDao(): CategoryDao
+    abstract fun menuItemDao(): MenuItemDao
+    abstract fun zoneDao(): ZoneDao
+    abstract fun tableSpotDao(): TableSpotDao
+    abstract fun orderDao(): OrderDao
+    abstract fun orderLineDao(): OrderLineDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: RetroBurgerDatabase? = null
+
+        fun getInstance(context: Context): RetroBurgerDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    RetroBurgerDatabase::class.java,
+                    "retro_burger.db"
+                ).addCallback(object : Callback() {
+                    override fun onCreate(db: SupportSQLiteDatabase) {
+                        super.onCreate(db)
+                        Executors.newSingleThreadExecutor().execute {
+                            INSTANCE?.let { database ->
+                                database.zoneDao().insertAll(SeedData.zones)
+                                database.tableSpotDao().insertAll(SeedData.tableSpots)
+                                database.categoryDao().insertAll(SeedData.categories)
+                                database.menuItemDao().insertAll(SeedData.menuItems)
+                            }
+                        }
+                    }
+                }).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/SeedData.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/SeedData.kt
@@ -1,0 +1,45 @@
+package com.gerardo.comandas.data.room
+
+object SeedData {
+    val categories = listOf(
+        Category(1, "Plato"),
+        Category(2, "Bebida")
+    )
+
+    val menuItems = listOf(
+        MenuItem(1, "MARILYN", 0.0, 1),
+        MenuItem(2, "ELVIS", 0.0, 1),
+        MenuItem(3, "PATTY MELT", 0.0, 1),
+        MenuItem(4, "STEVE MCQUEEN", 0.0, 1),
+        MenuItem(5, "GIVE ME MORE (NOSOLOBURGER)", 0.0, 1),
+        MenuItem(6, "POLLO CRUJIENTE", 0.0, 1),
+        MenuItem(7, "BACON CHESSE FRIES", 0.0, 1),
+        MenuItem(8, "NACHOS", 0.0, 1),
+        MenuItem(9, "ALITAS BUFFALO WINGS", 0.0, 1),
+        MenuItem(10, "COLA", 0.0, 2),
+        MenuItem(11, "AGUA", 0.0, 2)
+    )
+
+    val zones = listOf(
+        Zone(1, "Barra"),
+        Zone(2, "Bar"),
+        Zone(3, "Comedor")
+    )
+
+    val tableSpots: List<TableSpot> = run {
+        val tables = mutableListOf<TableSpot>()
+        var id = 1
+        zones.forEach { zone ->
+            val count = when (zone.id) {
+                1 -> 10
+                2 -> 6
+                3 -> 8
+                else -> 0
+            }
+            for (number in 1..count) {
+                tables.add(TableSpot(id++, number, zone.id))
+            }
+        }
+        tables
+    }
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/TableSpot.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/TableSpot.kt
@@ -1,0 +1,22 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "table_spots",
+    foreignKeys = [ForeignKey(
+        entity = Zone::class,
+        parentColumns = ["id"],
+        childColumns = ["zoneId"],
+        onDelete = ForeignKey.CASCADE
+    )],
+    indices = [Index("zoneId")]
+)
+data class TableSpot(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val number: Int,
+    val zoneId: Int
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/TableSpotDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/TableSpotDao.kt
@@ -1,0 +1,18 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface TableSpotDao {
+    @Query("SELECT * FROM table_spots")
+    suspend fun getAll(): List<TableSpot>
+
+    @Query("SELECT * FROM table_spots WHERE zoneId = :zoneId")
+    suspend fun getByZone(zoneId: Int): List<TableSpot>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(tables: List<TableSpot>)
+}

--- a/app/src/main/java/com/gerardo/comandas/data/room/Zone.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/Zone.kt
@@ -1,0 +1,10 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "zones")
+data class Zone(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String
+)

--- a/app/src/main/java/com/gerardo/comandas/data/room/ZoneDao.kt
+++ b/app/src/main/java/com/gerardo/comandas/data/room/ZoneDao.kt
@@ -1,0 +1,15 @@
+package com.gerardo.comandas.data.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ZoneDao {
+    @Query("SELECT * FROM zones")
+    suspend fun getAll(): List<Zone>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(zones: List<Zone>)
+}


### PR DESCRIPTION
## Summary
- add Room entities for menu items, categories, zones, tables, orders, and order lines
- implement DAOs and database with prepopulation
- include initial seed data and Room dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af00ae93d883299eb47225987658ec