### PR TITLE
feat: add RetroBurger theme and reusable components

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.navigation:navigation-compose:2.6.0")
     implementation("androidx.activity:activity-compose:1.10.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.2")

--- a/app/src/main/java/com/gerardo/comandas/MainActivity.kt
+++ b/app/src/main/java/com/gerardo/comandas/MainActivity.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -26,9 +25,10 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.gerardo.comandas.ui.theme.COMANDASTheme
+import com.gerardo.comandas.ui.theme.RetroBurgerTheme
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material3.TextField
+import com.gerardo.comandas.ui.components.PrimaryButton
+import com.gerardo.comandas.ui.components.OutlinedField
 import androidx.compose.foundation.Canvas
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.Offset
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            COMANDASTheme {
+            RetroBurgerTheme {
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main_screen") {
                     composable("main_screen") { MainScreen(navController = navController) }
@@ -157,14 +157,14 @@ fun PantallaConRibetes(navController: NavController, content: @Composable () -> 
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth().padding(16.dp)
         ) {
-            Button(
+            PrimaryButton(
                 onClick = { navController.popBackStack() },
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB0BEC5)),
                 modifier = Modifier.padding(8.dp)
             ) {
                 Text(text = "Atrás", color = Color.Black)
             }
-            Button(
+            PrimaryButton(
                 onClick = { navController.navigate("main_screen") },
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFB0BEC5)),
                 modifier = Modifier.padding(8.dp)
@@ -195,7 +195,7 @@ fun LoginScreen(navController: NavController) {
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            TextField(
+            OutlinedField(
                 value = code.value,
                 onValueChange = { input ->
                     if (input.length <= 3 && input.all { it.isDigit() }) {
@@ -212,7 +212,7 @@ fun LoginScreen(navController: NavController) {
                     .fillMaxWidth(0.6f)
                     .padding(vertical = 8.dp)
             )
-            Button(
+            PrimaryButton(
                 onClick = {
                     validateCodeAndNavigate(code.value, users, message, navController)
                 },
@@ -243,21 +243,21 @@ fun ZonasScreen(navController: NavController) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("barra_screen") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFCE9D6)),
                     modifier = Modifier.padding(8.dp)
                 ) {
                     Text(text = "Barra", color = Color.Black)
                 }
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("comedor_bar") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                     modifier = Modifier.padding(8.dp)
                 ) {
                     Text(text = "Comedor Bar", color = Color.Black)
                 }
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("comedor_principal") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFCE9D6)),
                     modifier = Modifier.padding(8.dp)
@@ -297,21 +297,21 @@ fun NextScreen(navController: NavController) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("barra_screen") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFCE9D6)),
                     modifier = Modifier.padding(8.dp)
                 ) {
                     Text(text = "Barra", color = Color.Black)
                 }
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("comedor_bar") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                     modifier = Modifier.padding(8.dp)
                 ) {
                     Text(text = "Comedor Bar", color = Color.Black)
                 }
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("comedor_principal") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFCE9D6)),
                     modifier = Modifier.padding(8.dp)
@@ -336,14 +336,14 @@ fun BarraScreen(navController: NavController) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("barra_comer_aqui") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                     modifier = Modifier.padding(8.dp)
                 ) {
                     Text(text = "Comer aquí", color = Color.Black)
                 }
-                Button(
+                PrimaryButton(
                     onClick = { navController.navigate("barra_para_llevar") },
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFCE9D6)),
                     modifier = Modifier.padding(8.dp)
@@ -369,7 +369,7 @@ fun BarraComerAquiScreen(navController: NavController) {
                 verticalArrangement = Arrangement.Center
             ) {
                 for (i in 1..10) {
-                    Button(
+                    PrimaryButton(
                         onClick = { navController.navigate("barra_comer_aqui_mesa_$i") },
                         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                         modifier = Modifier.padding(4.dp)
@@ -480,7 +480,7 @@ fun ComedorBarScreen(navController: NavController) {
                 verticalArrangement = Arrangement.Center
             ) {
                 for (i in 1..8) {
-                    Button(
+                    PrimaryButton(
                         onClick = { navController.navigate("comedor_bar_mesa_$i") },
                         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                         modifier = Modifier.padding(8.dp)
@@ -527,7 +527,7 @@ fun ComedorPrincipalScreen(navController: NavController) {
                 verticalArrangement = Arrangement.Center
             ) {
                 for (i in 1..12) {
-                    Button(
+                    PrimaryButton(
                         onClick = { navController.navigate("comedor_principal_mesa_$i") },
                         colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF7F9F)),
                         modifier = Modifier.padding(8.dp)
@@ -566,14 +566,14 @@ fun ComidaYBebidaButtons(navController: NavController) {
         horizontalArrangement = Arrangement.SpaceEvenly,
         modifier = Modifier.fillMaxWidth().padding(16.dp)
     ) {
-        Button(
+        PrimaryButton(
             onClick = { navController.navigate("comida_screen") },
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFFC107)),
             modifier = Modifier.padding(8.dp)
         ) {
             Text(text = "Comida", color = Color.Black)
         }
-        Button(
+        PrimaryButton(
             onClick = { navController.navigate("bebida_screen") },
             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF03A9F4)),
             modifier = Modifier.padding(8.dp)
@@ -630,7 +630,7 @@ fun BebidaScreen(navController: NavController, showButtons: Boolean = true) {
                 )
                 for ((nombre, descripcion) in bebidas) {
                     if (showButtons) {
-                        Button(
+                        PrimaryButton(
                             onClick = { navController.navigate("detalle_bebida_screen/$nombre/$descripcion") },
                             colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF03A9F4)),
                             modifier = Modifier.padding(8.dp)

--- a/app/src/main/java/com/gerardo/comandas/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/components/AppTopBar.kt
@@ -1,0 +1,23 @@
+package com.gerardo.comandas.ui.components
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+
+@Composable
+fun AppTopBar(title: String, onBack: (() -> Unit)? = null) {
+    CenterAlignedTopAppBar(
+        title = { Text(title) },
+        navigationIcon = {
+            if (onBack != null) {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = null)
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/gerardo/comandas/ui/components/CardListItem.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/components/CardListItem.kt
@@ -1,0 +1,23 @@
+package com.gerardo.comandas.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CardListItem(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), content = content)
+    }
+}

--- a/app/src/main/java/com/gerardo/comandas/ui/components/EmptyState.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/components/EmptyState.kt
@@ -1,0 +1,20 @@
+package com.gerardo.comandas.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun EmptyState(message: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = message, textAlign = TextAlign.Center, color = Color.Gray)
+    }
+}

--- a/app/src/main/java/com/gerardo/comandas/ui/components/OutlinedField.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/components/OutlinedField.kt
@@ -1,0 +1,36 @@
+package com.gerardo.comandas.ui.components
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+
+@Composable
+fun OutlinedField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = true,
+    colors: TextFieldColors = TextFieldDefaults.outlinedTextFieldColors()
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        label = label,
+        placeholder = placeholder,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = singleLine,
+        colors = colors,
+        shape = RoundedCornerShape(16.dp)
+    )
+}

--- a/app/src/main/java/com/gerardo/comandas/ui/components/PrimaryButton.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/components/PrimaryButton.kt
@@ -1,0 +1,28 @@
+package com.gerardo.comandas.ui.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PrimaryButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = colors,
+        shape = RoundedCornerShape(16.dp),
+        content = content
+    )
+}

--- a/app/src/main/java/com/gerardo/comandas/ui/theme/Theme.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/theme/Theme.kt
@@ -4,12 +4,15 @@ import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
 
 private val BrandLightColorScheme = lightColorScheme(
     primary = BrandPrimary,
@@ -37,8 +40,14 @@ private val BrandDarkColorScheme = darkColorScheme(
     onSurface = White
 )
 
+private val RetroShapes = Shapes(
+    small = RoundedCornerShape(16.dp),
+    medium = RoundedCornerShape(18.dp),
+    large = RoundedCornerShape(20.dp)
+)
+
 @Composable
-fun COMANDASTheme(
+fun RetroBurgerTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
@@ -56,6 +65,7 @@ fun COMANDASTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
+        shapes = RetroShapes,
         content = content
     )
 }

--- a/app/src/main/java/com/gerardo/comandas/ui/theme/Type.kt
+++ b/app/src/main/java/com/gerardo/comandas/ui/theme/Type.kt
@@ -9,11 +9,18 @@ import androidx.compose.ui.unit.sp
 // Set of Material typography styles to start with
 val Typography = Typography(
     bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
     )
     /* Other default text styles to override
     titleLarge = TextStyle(


### PR DESCRIPTION
## Summary
- add RetroBurgerTheme with rounded shapes and dark-mode support
- create reusable UI components: AppTopBar, PrimaryButton, OutlinedField, CardListItem, EmptyState
- replace direct Button/TextField usage with custom components and add material icons dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af00a851a8832994764a3d33f0fd36